### PR TITLE
Bump rock version for release

### DIFF
--- a/kong-datadog-k8s-0.1.0-1.rockspec
+++ b/kong-datadog-k8s-0.1.0-1.rockspec
@@ -1,5 +1,5 @@
 package = "kong-datadog-k8s"
-version = "0.1.0-0"
+version = "0.1.0-1"
 
 source = {
    url = "git://github.com/erran/kong-datadog-k8s",


### PR DESCRIPTION
I made an uh-oh releasing `0.1.0-0` and bumping to `0.1.0-1` allowed me to release so 🤷‍♂.