### PR TITLE
Fix duplicate migration names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ luac.out
 *.src.rock
 *.zip
 *.tar.gz
+kong-datadog-k8s*/
 
 # Object files
 *.o
@@ -38,4 +39,3 @@ luac.out
 *.i*86
 *.x86_64
 *.hex
-

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # kong-datadog-k8s
+![erran/kong-datadog-k8s luarocks badge][] ![tested with badge][]
+
 A fork of the bundled datadog plugin which supports passing host as an environment variable
+
+**Tested with Kong v0.14.1.**
+
+[erran/kong-datadog-k8s luarocks badge]: https://img.shields.io/luarocks/v/erran/kong-datadog-k8s/0.0.1-1.svg
+[tested with badge]: https://img.shields.io/badge/kong-v0.14.1-9cf.svg

--- a/kong-datadog-k8s-0.0.1-1.rockspec
+++ b/kong-datadog-k8s-0.0.1-1.rockspec
@@ -1,5 +1,5 @@
 package = "kong-datadog-k8s"
-version = "0.0.1-0"
+version = "0.0.1-1"
 
 source = {
    url = "git://github.com/erran/kong-datadog-k8s",

--- a/src/kong/plugins/datadog-k8s/migrations/cassandra.lua
+++ b/src/kong/plugins/datadog-k8s/migrations/cassandra.lua
@@ -1,6 +1,6 @@
 return {
   {
-    name = "2017-06-09-160000_datadog_schema_changes",
+    name = "2019-10-10-000000_datadog_k8s_schema_changes",
     up = function(_, _, dao)
 
       local plugins, err = dao.plugins:find_all { name = "datadog-k8s" }

--- a/src/kong/plugins/datadog-k8s/migrations/postgres.lua
+++ b/src/kong/plugins/datadog-k8s/migrations/postgres.lua
@@ -1,6 +1,6 @@
 return {
   {
-    name = "2017-06-09-160000_datadog_schema_changes",
+    name = "2019-10-10-000000_datadog_k8s_schema_changes",
     up = function(_, _, dao)
 
       local plugins, err = dao.plugins:find_all { name = "datadog-k8s" }


### PR DESCRIPTION
Kong failed to start due to conflicting migration names where the bundled datadog plugin was installed.